### PR TITLE
Updating dependencies to v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "lodash": "~2.0.0",
-    "waterline-criteria": "git://github.com/balderdashy/waterline-criteria.git#associations"
+    "waterline-criteria": "git://github.com/balderdashy/waterline-criteria.git#v0.10"
   },
   "devDependencies": {
     "mocha": "~1.13.0",
-    "waterline-adapter-tests": "git://github.com/balderdashy/waterline-adapter-tests.git#associations"
+    "waterline-adapter-tests": "git://github.com/balderdashy/waterline-adapter-tests.git#v0.10"
   }
 }


### PR DESCRIPTION
The dependency branches (associations) for waterline-criteria and waterline-adapter-tests do not exist anymore. 

I would also suggest making this a v0.10 branch just to be consistent.

Cheers,
Sean
