### PR TITLE
Database.enforceUniqueness() works even when values doesn't contain an id.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -282,10 +282,12 @@ Database.prototype.update = function(collectionName, options, values, cb) {
 
   // Filter Data based on Options criteria
   var resultSet = waterlineCriteria(collectionName, this.data, options);
+  var resultIds = _.pluck(resultSet.results, 'id');
 
-  // Enforce uniquness constraints
+  // Enforce uniqueness constraints, indicating which records are updated
+  // in case `values` doesn't contain an id.
   // If uniqueness constraints were violated, send back a validation error.
-  var violations = self.enforceUniqueness(collectionName, values);
+  var violations = self.enforceUniqueness(collectionName, values, resultIds);
   if (violations.length) {
     return cb(new UniquenessError(violations));
   }
@@ -413,11 +415,14 @@ Database.prototype.serializeValues = function(collectionName, values) {
  *
  * @param {String} collectionName
  * @param {Object} values           - attribute values for a single record
+ * @param {Array} updatedIds        - when updating the id is not necessarily included
+ *     in the values to update, the ids of the records that will be updated is used when
+ *     testing uniqueness of relevant attributes.
  * @return {Object}
  * @api private
  */
 
-Database.prototype.enforceUniqueness = function(collectionName, values) {
+Database.prototype.enforceUniqueness = function(collectionName, values, updatedIds) {
 
   var errors = [];
 
@@ -439,10 +444,14 @@ Database.prototype.enforceUniqueness = function(collectionName, values) {
       // Does it look like a "uniqueness violation"?
       if (values[attrName] === this.data[collectionName][index][attrName]) {
 
-        // It isn't actually a uniquness violation if the record
-        // we're checking is the same as the record we're updating/creating
-        if (values[pkAttrName] === this.data[collectionName][index][pkAttrName]) {
-          continue;
+        // It isn't actually a uniqueness violation if the record(s)
+        // we're checking is the same as the record(s) we're updating/creating
+        if (_.isUndefined(values[pkAttrName])) {
+          if (updatedIds && updatedIds.indexOf(this.data[collectionName][index][pkAttrName]) > -1) {
+            continue; // Id was found in the list of records being updated.
+          }
+        } else if (values[pkAttrName] === this.data[collectionName][index][pkAttrName]) {
+          continue; // This is the data of the single record being updated.
         }
 
         var uniquenessError = {


### PR DESCRIPTION
When updating multiple records based on a given find criteria there won't be an `id` specified in the object with the new values. This caused the check in `Database.enforceUniqueness()` to fail since it relied solely on the id in the values for this check. My solution is to provide the `ids` of the records being updated to this method so they can be used for this check if the id wasn't given.

There was no test for this bug, so I added one to the waterline-adapter-tests via the PR at balderdashy/waterline-adapter-tests#63. Even if the test isn't merged there, this fix could still be applied here.