### PR TITLE
Auto inc continues counting after a provided value.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -350,9 +350,14 @@ Database.prototype.autoIncrement = function(collectionName, values) {
   for (var attrName in this.schema[collectionName]) {
     var attrDef = this.schema[collectionName][attrName];
 
-    // Only apply autoIncrement if value is not specified
     if(!attrDef.autoIncrement) continue;
-    if(values[attrName]) continue;
+
+    // Only apply autoIncrement if value is not specified
+    // If it is, set the counter to this value so the next increment will continue after it.
+    if(values[attrName]) {
+      this.counters[collectionName][attrName] = values[attrName];
+      continue;
+    }
 
     // Set Initial Counter Value to 0 for this attribute if not set
     if(!this.counters[collectionName][attrName]) this.counters[collectionName][attrName] = 0;

--- a/lib/database.js
+++ b/lib/database.js
@@ -352,21 +352,27 @@ Database.prototype.autoIncrement = function(collectionName, values) {
 
     if(!attrDef.autoIncrement) continue;
 
+    // Save many look-ups and many chars after minification
+    var counters = this.counters[collectionName];
+
     // Only apply autoIncrement if value is not specified
-    // If it is, set the counter to this value so the next increment will continue after it.
     if(values[attrName]) {
-      this.counters[collectionName][attrName] = values[attrName];
+      // If it is and is larger, set the counter to this value so the next increment will continue after it.
+      // Test for an undefined counter, since `1 > undefined === false`
+      if (!counters[attrName] || values[attrName] > counters[attrName]) {
+        counters[attrName] = values[attrName];
+      }
       continue;
     }
 
     // Set Initial Counter Value to 0 for this attribute if not set
-    if(!this.counters[collectionName][attrName]) this.counters[collectionName][attrName] = 0;
+    if(!counters[attrName]) counters[attrName] = 0;
 
     // Increment AI counter
-    this.counters[collectionName][attrName]++;
+    counters[attrName]++;
 
     // Set data to current auto-increment value
-    values[attrName] = this.counters[collectionName][attrName];
+    values[attrName] = counters[attrName];
   }
 
   return values;


### PR DESCRIPTION
Auto increment counters are maintained for relevant attributes, and when an attribute value for such a field is provided in the values object incrementing the associated counter is skipped. This may result in duplicate values which, I imagine, is usually not desired, when for example a fixture with a specified `id` of `1` is inserted into the db and then another record gets added thereafter. It does, in fact, generate two records with the same `id` of `1` which led me to discovering this issue.

My solution is setting the auto inc counter to the provided value when present. This allows the counter to continue incrementing to the following value on the next insertion. 

The assumption that a new record with a specified value will not be lower than the current auto inc counter is still being made, but the problem of duplicate values should be largely reduced. 

(Thinking about it again this problem will mostly occur in the case where fixtures are loaded, since all programmatic insertions won't provide an id. Still, since this is an *in-memory* store used in dev environments I'd imagine that being a very common use case.)