### PR TITLE
Honor columnName mapping.

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -238,7 +238,7 @@ Database.prototype.insert = function(collectionName, values, cb) {
 
   // To hold any uniqueness constraint violations we encounter:
   var constraintViolations = [];
-  
+
   // Iterate over each record being inserted, deal w/ auto-incrementing
   // and checking the uniquness constraints.
   for (var i in values) {
@@ -398,7 +398,7 @@ Database.prototype.mapColumnNames = function(collectionName, values) {
   // Map fields to columnNames if present.
   _.keys(values).forEach(function(key) {
     // If columnName is present and they are not the same
-    if (schema[key].columnName && schema[key].columnName !== key) {
+    if (schema[key] && schema[key].columnName && schema[key].columnName !== key) {
       record[schema[key].columnName] = values[key];
       delete values[key];
     }

--- a/lib/database.js
+++ b/lib/database.js
@@ -237,7 +237,8 @@ Database.prototype.insert = function(collectionName, values, cb) {
   if(!Array.isArray(values)) values = [values];
 
   // To hold any uniqueness constraint violations we encounter:
-
+  var constraintViolations = [];
+  
   // Iterate over each record being inserted, deal w/ auto-incrementing
   // and checking the uniquness constraints.
   for (var i in values) {

--- a/lib/database.js
+++ b/lib/database.js
@@ -237,7 +237,6 @@ Database.prototype.insert = function(collectionName, values, cb) {
   if(!Array.isArray(values)) values = [values];
 
   // To hold any uniqueness constraint violations we encounter:
-  var constraintViolations = [];
 
   // Iterate over each record being inserted, deal w/ auto-incrementing
   // and checking the uniquness constraints.
@@ -252,6 +251,7 @@ Database.prototype.insert = function(collectionName, values, cb) {
     // Auto-Increment any values that need it
     record = self.autoIncrement(collectionName, record);
     record = self.serializeValues(collectionName, record);
+    record = self.mapColumnNames(collectionName, record);
 
     if (!self.data[collectionName]) return cb(Errors.CollectionNotRegistered);
     self.data[collectionName].push(record);
@@ -376,6 +376,32 @@ Database.prototype.autoIncrement = function(collectionName, values) {
     // Set data to current auto-increment value
     values[attrName] = counters[attrName];
   }
+
+  return values;
+};
+
+/**
+ * Map Column Names
+ *
+ * Map record's keys to their appropriate columnName values if present.
+ *
+ * @param {String} collectionName
+ * @param {Object} values
+ * @return {Object}
+ * @api private
+ */
+
+Database.prototype.mapColumnNames = function(collectionName, values) {
+  var schema = this.schema[collectionName];
+
+  // Map fields to columnNames if present.
+  _.keys(values).forEach(function(key) {
+    // If columnName is present and they are not the same
+    if (schema[key].columnName && schema[key].columnName !== key) {
+      record[schema[key].columnName] = values[key];
+      delete values[key];
+    }
+  });
 
   return values;
 };

--- a/lib/database.js
+++ b/lib/database.js
@@ -399,7 +399,7 @@ Database.prototype.mapColumnNames = function(collectionName, values) {
   _.keys(values).forEach(function(key) {
     // If columnName is present and they are not the same
     if (schema[key] && schema[key].columnName && schema[key].columnName !== key) {
-      record[schema[key].columnName] = values[key];
+      values[schema[key].columnName] = values[key];
       delete values[key];
     }
   });


### PR DESCRIPTION
Resolve #25.

If a columnName is present on a field, use that instead.
