### PR TITLE
Closes #15

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -464,8 +464,6 @@ Database.prototype.enforceUniqueness = function(collectionName, values, updatedI
           if (updatedIds && updatedIds.indexOf(this.data[collectionName][index][pkAttrName]) > -1) {
             continue; // Id was found in the list of records being updated.
           }
-        } else if (values[pkAttrName] === this.data[collectionName][index][pkAttrName]) {
-          continue; // This is the data of the single record being updated.
         }
 
         var uniquenessError = {


### PR DESCRIPTION
Just because the primary key is unchanged doesn't mean the uniqueness check shouldn't be enforced.

I.e. if we have a table where the primary key is an email or whatever, the uniqueness check here breaks. This PR fixes that.